### PR TITLE
Drop pointer events immediately when a notification starts closing

### DIFF
--- a/peak_flow.yml
+++ b/peak_flow.yml
@@ -1,4 +1,16 @@
 before_script:
+  # expo-module prepare (run by npm install's prepare script) shells out to rsync,
+  # which is not present in the build image. Install it before npm install.
+  - >-
+    sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get
+    -o Acquire::Retries=5
+    -o Acquire::http::Timeout=30
+    -o Acquire::https::Timeout=30
+    update
+  - >-
+    sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get
+    -o Acquire::Retries=5
+    install -y rsync
   - npm install
 script:
   - npm run test

--- a/src/container/index.jsx
+++ b/src/container/index.jsx
@@ -118,6 +118,12 @@ export default memo(shapeComponent(
       <View
         // @ts-expect-error
         dataSet={this.rootViewDataSet ||= {component: "flash-notifications-container"}}
+        // "box-none" so the fixed, high-zIndex container never intercepts pointer events on its own
+        // bounds: empty gaps pass through, and a fading notification (whose wrapper is set to
+        // pointerEvents="none" while removing) passes through too, while a live notification still
+        // receives its own presses. Without this the container itself would swallow clicks/fills
+        // aimed at the form beneath it during a notification's fade-out.
+        pointerEvents="box-none"
         // @ts-expect-error React Native types do not include the web-only "fixed" position.
         style={viewStyle}
         testID="flash-notificaitons/container"

--- a/src/container/index.jsx
+++ b/src/container/index.jsx
@@ -132,6 +132,7 @@ export default memo(shapeComponent(
             notification={notification}
             onMeasured={this.onNotificationMeasured}
             onRemovedClicked={this.onRemovedClicked}
+            removing={notification.removing}
             title={notification.title}
             type={notification.type}
           />
@@ -244,8 +245,12 @@ export default memo(shapeComponent(
       debugLog("FlashNotifications: notification missing measured height", {id: notification.count})
       notification.measuredHeight = 1
       notification.height.setValue(1)
-      this.setState({notifications: [...this.s.notifications]})
     }
+
+    // Re-render immediately so the closing notification drops pointer events (pointerEvents="none")
+    // the instant it starts fading out. Otherwise the fading overlay keeps intercepting the next
+    // click/fill for the whole fade duration even though it is on its way out.
+    this.setState({notifications: [...this.s.notifications]})
 
     debugLog("FlashNotifications: animations begin", {
       id: notification.count,

--- a/src/container/notification.jsx
+++ b/src/container/notification.jsx
@@ -30,6 +30,7 @@ import {useBreakpoint} from "responsive-breakpoints"
  * @property {StoredNotificationType} notification
  * @property {(notification: StoredNotificationType, measuredHeight: number) => void} onMeasured
  * @property {(notification: StoredNotificationType) => void} onRemovedClicked
+ * @property {boolean} removing
  * @property {string} title
  * @property {string} type
  */
@@ -52,12 +53,13 @@ class FlashNotificationsNotification extends ShapeComponent {
     notification: PropTypes.object.isRequired,
     onMeasured: PropTypes.func.isRequired,
     onRemovedClicked: PropTypes.func.isRequired,
+    removing: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired
   })
 
   render() {
-    const {count, message, title, type} = this.p
+    const {count, message, removing, title, type} = this.p
     const {className} = this.props
     const breakpoint = useBreakpoint()
 
@@ -70,7 +72,10 @@ class FlashNotificationsNotification extends ShapeComponent {
       [className, type]
     )
     return (
-      <Animated.View style={this.tt.wrapperStyle}>
+      <Animated.View
+        pointerEvents={removing ? "none" : "auto"}
+        style={this.tt.wrapperStyle}
+      >
         <Pressable
           // @ts-expect-error React Native types do not include the web-only dataSet prop.
           dataSet={pressableDataSet}


### PR DESCRIPTION
## Problem

A fading flash notification kept intercepting the next click/fill for the whole 80-200ms fade. The notification's `Pressable` retained active pointer events until the notification was removed from React state at the *end* of the dismiss animation. Consumers (e.g. system tests) that act immediately after dismissing a success flash — such as the ticket-app sign-in flow, which shows a "You were signed in" flash and then fills a form / clicks a header control — could have their input fill or pointer-action click swallowed by the still-present, fading overlay.

`waitForNoSelector` in the harness returns as soon as the element is not *displayed*, but the DOM node lingers (with active pointer events) for the rest of the fade, so the race window is real.

## Fix

Follow the standard "disable pointer events immediately when closing starts" pattern:

- Set `pointerEvents="none"` on the notification wrapper the instant it starts closing. A new required `removing` prop (a primitive, so `memo` re-renders when it flips) drives it.
- Force a re-render at the start of `dismissNotification` so the `removing` flag reaches the DOM *before* the fade animation begins, instead of only after it completes.

Once closing starts, the overlay can no longer receive pointer events, eliminating the whole class of post-dismiss interception races.

## Verification

Consumed by ticket-app (customer app) via the libraries-watcher local build. The three previously-flaky ticket-app system specs (my-profile, order-history, tickets-show) that act right after the sign-in flash now pass 5/5 each individually plus 2 batch runs of all three together — 17/17 executions green with zero in-test retries. Package `npm run lint` (eslint + typecheck) green.