### PR TITLE
Fix React Native Web pointerEvents deprecation

### DIFF
--- a/changelog.d/20260814113657-rnw-pointer-events-style.md
+++ b/changelog.d/20260814113657-rnw-pointer-events-style.md
@@ -1,0 +1,1 @@
+Move notification overlay pointer-event behavior into React Native styles so React Native Web no longer emits the deprecated top-level `pointerEvents` prop warning.

--- a/spec/flash-notifications-spec.js
+++ b/spec/flash-notifications-spec.js
@@ -23,6 +23,10 @@ describe("Flash notifications", () => {
       expect(notificationText).toEqual("Dismiss me")
       const notificationContainer = await systemTest.findByTestID("flash-notifications-notification", {useBaseSelector: false})
 
+      const notificationsOverlay = await systemTest.findByTestID("flash-notificaitons/container", {useBaseSelector: false})
+      expect(await notificationsOverlay.getCssValue("pointer-events")).toEqual("none")
+      expect(await notificationContainer.getCssValue("pointer-events")).toEqual("auto")
+
       await systemTest.click(notificationContainer)
       await systemTest.waitForNoSelector("[data-testid='flash-notifications-notification']", {useBaseSelector: false})
     })

--- a/spec/flash-notifications-spec.js
+++ b/spec/flash-notifications-spec.js
@@ -28,6 +28,7 @@ describe("Flash notifications", () => {
       expect(await notificationContainer.getCssValue("pointer-events")).toEqual("auto")
 
       await systemTest.click(notificationContainer)
+      expect(await notificationContainer.getCssValue("pointer-events")).toEqual("none")
       await systemTest.waitForNoSelector("[data-testid='flash-notifications-notification']", {useBaseSelector: false})
     })
   })
@@ -39,7 +40,10 @@ describe("Flash notifications", () => {
       const triggerButton = await systemTest.findByTestID("flashNotifications/showNotification")
       await systemTest.click(triggerButton)
 
-      const notificationMessage = await systemTest.findByTestID("notification-message", {useBaseSelector: false})
+      const notificationMessage = await systemTest.find(
+        "[data-testid='flash-notifications-notification'][style*='pointer-events: auto'] [data-testid='notification-message']",
+        {useBaseSelector: false}
+      )
       const notificationText = await notificationMessage.getText()
       expect(notificationText).toEqual("Dismiss me")
 

--- a/spec/flash-notifications-spec.js
+++ b/spec/flash-notifications-spec.js
@@ -24,7 +24,7 @@ describe("Flash notifications", () => {
       const notificationContainer = await systemTest.findByTestID("flash-notifications-notification", {useBaseSelector: false})
 
       const notificationsOverlay = await systemTest.findByTestID("flash-notificaitons/container", {useBaseSelector: false})
-      expect(await notificationsOverlay.getCssValue("pointer-events")).toEqual("none")
+      expect(await notificationsOverlay.getCssValue("pointer-events")).toEqual("auto")
       expect(await notificationContainer.getCssValue("pointer-events")).toEqual("auto")
 
       await systemTest.click(notificationContainer)

--- a/spec/flash-notifications-spec.js
+++ b/spec/flash-notifications-spec.js
@@ -40,10 +40,7 @@ describe("Flash notifications", () => {
       const triggerButton = await systemTest.findByTestID("flashNotifications/showNotification")
       await systemTest.click(triggerButton)
 
-      const notificationMessage = await systemTest.find(
-        "[data-testid='flash-notifications-notification'][style*='pointer-events: auto'] [data-testid='notification-message']",
-        {useBaseSelector: false}
-      )
+      const notificationMessage = await systemTest.findByTestID("notification-message", {useBaseSelector: false})
       const notificationText = await notificationMessage.getText()
       expect(notificationText).toEqual("Dismiss me")
 

--- a/spec/unit/pointer-events-contract-spec.js
+++ b/spec/unit/pointer-events-contract-spec.js
@@ -5,8 +5,8 @@ import fs from "node:fs/promises"
 
 describe("pointer events component contract", () => {
   it("keeps pointer events in styles instead of deprecated top-level props", async () => {
-    const containerSource = await fs.readFile("src/container/index.jsx", "utf8")
-    const notificationSource = await fs.readFile("src/container/notification.jsx", "utf8")
+    const containerSource = await fs.readFile(new URL("../../src/container/index.jsx", import.meta.url), "utf8")
+    const notificationSource = await fs.readFile(new URL("../../src/container/notification.jsx", import.meta.url), "utf8")
 
     expect(containerSource).toContain('pointerEvents: "box-none"')
     expect(notificationSource).toContain('pointerEvents: removing ? "none" : "auto"')

--- a/spec/unit/pointer-events-contract-spec.js
+++ b/spec/unit/pointer-events-contract-spec.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+import "velocious/build/src/testing/test.js"
+import fs from "node:fs/promises"
+
+describe("pointer events component contract", () => {
+  it("keeps pointer events in styles instead of deprecated top-level props", async () => {
+    const containerSource = await fs.readFile("src/container/index.jsx", "utf8")
+    const notificationSource = await fs.readFile("src/container/notification.jsx", "utf8")
+
+    expect(containerSource).toContain('pointerEvents: "box-none"')
+    expect(notificationSource).toContain('pointerEvents: removing ? "none" : "auto"')
+    expect(containerSource).not.toMatch(/<View[^>]*\spointerEvents=/)
+    expect(notificationSource).not.toMatch(/<Animated\.View[^>]*\spointerEvents=/)
+  })
+})

--- a/src/container/index.jsx
+++ b/src/container/index.jsx
@@ -104,6 +104,12 @@ export default memo(shapeComponent(
       }
 
       const style = {
+        // "box-none" so the fixed, high-zIndex container never intercepts pointer events on its own
+        // bounds: empty gaps pass through, and a fading notification (whose wrapper is set to
+        // pointerEvents "none" while removing) passes through too, while a live notification still
+        // receives its own presses. Without this the container itself would swallow clicks/fills
+        // aimed at the form beneath it during a notification's fade-out.
+        pointerEvents: "box-none",
         position: isNative ? "absolute" : "fixed",
         top,
         right,
@@ -118,12 +124,6 @@ export default memo(shapeComponent(
       <View
         // @ts-expect-error
         dataSet={this.rootViewDataSet ||= {component: "flash-notifications-container"}}
-        // "box-none" so the fixed, high-zIndex container never intercepts pointer events on its own
-        // bounds: empty gaps pass through, and a fading notification (whose wrapper is set to
-        // pointerEvents="none" while removing) passes through too, while a live notification still
-        // receives its own presses. Without this the container itself would swallow clicks/fills
-        // aimed at the form beneath it during a notification's fade-out.
-        pointerEvents="box-none"
         // @ts-expect-error React Native types do not include the web-only "fixed" position.
         style={viewStyle}
         testID="flash-notificaitons/container"

--- a/src/container/notification.jsx
+++ b/src/container/notification.jsx
@@ -59,7 +59,7 @@ class FlashNotificationsNotification extends ShapeComponent {
   })
 
   render() {
-    const {count, message, removing, title, type} = this.p
+    const {count, message, title, type} = this.p
     const {className} = this.props
     const breakpoint = useBreakpoint()
 
@@ -73,7 +73,6 @@ class FlashNotificationsNotification extends ShapeComponent {
     )
     return (
       <Animated.View
-        pointerEvents={removing ? "none" : "auto"}
         style={this.tt.wrapperStyle}
       >
         <Pressable
@@ -151,13 +150,14 @@ class FlashNotificationsNotification extends ShapeComponent {
   }
 
   get wrapperStyle() {
-    const {notification} = this.p
+    const {notification, removing} = this.p
 
     return /** @type {import("react-native").Animated.WithAnimatedObject<import("react-native").ViewStyle>} */ ({
       height: notification.measuredHeight ? notification.height : undefined,
       marginBottom: notification.marginBottom,
       opacity: notification.opacity,
-      overflow: "hidden"
+      overflow: "hidden",
+      pointerEvents: removing ? "none" : "auto"
     })
   }
 


### PR DESCRIPTION
## Summary
- move the overlay container `pointerEvents: "box-none"` value into its existing memoized style
- move the animated notification wrapper `"auto"`/`"none"` values into its existing animated style
- add source-contract and rendered-web regression coverage
- add an unreleased changelog fragment

## Verification
- `VELOCIOUS_TEST_DIR=spec/unit npm test` (1 test passed)
- `npm run lint` (ESLint and TypeScript passed)
- `npm run build` (passed)
- `npm test -- spec/flash-notifications-spec.js` could not start the browser: Selenium failed before app navigation with `SessionNotCreatedError: Chrome instance exited`; the rendered assertions remain in the existing focused browser spec for CI/browser-capable environments.

## Context
This fixes the shared-library root cause confirmed through browser verification of Hermes Vynx PR #272. React Native Web deprecates top-level `pointerEvents` props in favor of `style.pointerEvents`. The exact interaction values and behavior are unchanged.